### PR TITLE
chore: allow illuminate/* ^13.0 for Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "require": {
         "php": "^8.4",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^12.0",
-        "illuminate/database": "^12.0",
-        "illuminate/support": "^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "spatie/laravel-activitylog": "^5.0",
         "spatie/laravel-package-tools": "^1.16"
     },


### PR DESCRIPTION
Broadens the three illuminate/* constraints from ^12.0 to ^12.0|^13.0 to support Laravel 13.