### PR TITLE
fix: cap related-row fetch in RelatedActivityLogSource (#14)

### DIFF
--- a/src/Timeline/Sources/RelatedActivityLogSource.php
+++ b/src/Timeline/Sources/RelatedActivityLogSource.php
@@ -33,7 +33,7 @@ final class RelatedActivityLogSource extends AbstractTimelineSource
             $morphClass = (new $relatedClass)->getMorphClass();
 
             /** @var EloquentCollection<int, Model> $rows */
-            $rows = $subject->{$relation}()->get();
+            $rows = $subject->{$relation}()->limit($window->cap)->get();
 
             foreach ($rows as $row) {
                 $subjectPairs[] = [$morphClass, (string) $row->getKey()];


### PR DESCRIPTION
## Summary

Fixes #14. `RelatedActivityLogSource::resolve()` loaded **all** related rows into memory before querying the activity log, causing N+1 / memory blow-up for subjects with thousands of related rows (e.g., a Person with 10k tasks).

## Change

`src/Timeline/Sources/RelatedActivityLogSource.php:36` — add `->limit($window->cap)` to the related-row fetch so it matches the cap already applied to the activity-log query downstream.

```php
$rows = $subject->{$relation}()->limit($window->cap)->get();
```

## Test plan

- [x] Existing `tests/Feature/RelatedActivityLogSourceTest.php` passes (3 tests, 4 assertions)
- [ ] Verify behavior on a Person subject with >cap related rows in a downstream consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)