### PR TITLE
fix: remove dead 'date_groups' config key (#10)

### DIFF
--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -14,8 +14,6 @@ return [
         'custom' => 30,
     ],
 
-    'date_groups' => ['today', 'yesterday', 'this_week', 'last_week', 'this_month', 'older'],
-
     'renderers' => [
         // 'email_sent' => \App\Timeline\Renderers\EmailSentRenderer::class,
     ],

--- a/docs/content/3.essentials/6.configuration.md
+++ b/docs/content/3.essentials/6.configuration.md
@@ -29,9 +29,9 @@ Every knob the package exposes lives in `config/activity-log.php`. Publish it wi
 ## Removed key: `date_groups`
 
 ::callout{icon="i-lucide-alert-triangle" color="warning"}
-Earlier docs (and the published config still ships) a `date_groups` key listing 6 bucket labels (`today`, `yesterday`, `this_week`, `last_week`, `this_month`, `older`).
+Earlier versions of `config/activity-log.php` shipped a `date_groups` key listing 6 bucket labels (`today`, `yesterday`, `this_week`, `last_week`, `this_month`, `older`). It has been removed.
 
-**The key is dead.** `Grep src/` returns zero references. The actual buckets emitted by `ActivityLogLivewire::bucketFor()` are `this_week`, `last_week`, and `week_of <date>` (3 buckets, not 6).
+**The key was dead.** `Grep src/` returns zero references. The actual buckets emitted by `ActivityLogLivewire::bucketFor()` are `this_week`, `last_week`, and `week_of <date>` (3 buckets, not 6).
 
 Do NOT add `date_groups` to your published config expecting the buckets to change — it has no effect.
 


### PR DESCRIPTION
## Summary

Closes #10.

The `date_groups` key in `config/activity-log.php` was never read by application code — the timeline buckets are computed by `ActivityLogLivewire::bucketFor()` and ignore config entirely. Shipping the key was misleading: users could set it and see no effect.

## Changes

- `config/activity-log.php`: drop unused `date_groups` array.
- `docs/content/3.essentials/6.configuration.md`: update the "Removed key" note to past-tense now that the key is actually gone.

Picked Option 1 from the issue (delete) over Option 2 (wire up) — lower risk, matches current behavior, and the docs were already steering users away from the key.

## Test plan

- [x] `php -l config/activity-log.php` — no syntax errors
- [x] `grep -rn "date_groups" src/` — zero references (confirms nothing broke)
- [ ] Verify docs render cleanly on preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)