### PR TITLE
Add visible empty state to activity-log timeline

### DIFF
--- a/resources/views/timeline.blade.php
+++ b/resources/views/timeline.blade.php
@@ -1,6 +1,11 @@
 <div class="flex flex-col gap-6">
     @if ($entries->isEmpty())
-        <p class="text-sm text-gray-500 dark:text-gray-400">{{ $emptyState }}</p>
+        <div class="flex flex-col items-center justify-center gap-3 py-10 text-center">
+            <div class="flex h-11 w-11 items-center justify-center rounded-full bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-gray-500">
+                <x-filament::icon icon="ri-history-line" class="h-5 w-5" />
+            </div>
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $emptyState }}</p>
+        </div>
     @elseif ($grouped !== null)
         @foreach ($grouped as $label => $groupEntries)
             <section x-data="{ open: true }" wire:key="timeline-group-{{ $label }}">

--- a/src/Filament/RelationManagers/ActivityLogRelationManager.php
+++ b/src/Filament/RelationManagers/ActivityLogRelationManager.php
@@ -31,6 +31,8 @@ final class ActivityLogRelationManager extends RelationManager
 
     public static int $perPage = 20;
 
+    public static ?string $emptyState = null;
+
     public function content(Schema $schema): Schema
     {
         $owner = $this->getOwnerRecord();
@@ -44,6 +46,7 @@ final class ActivityLogRelationManager extends RelationManager
                         'groupByDate' => self::$groupByDate,
                         'perPage' => self::$perPage,
                         'infiniteScroll' => self::$infiniteScroll,
+                        'emptyState' => static::$emptyState ?? (string) __('activity-log::messages.empty_state'),
                     ])->key('activity-log-relation-manager-'.$owner->getKey()),
                 ]),
         ]);


### PR DESCRIPTION
## What

Replaces the minimal, easy-to-miss empty-state paragraph in the activity-log timeline with a proper centered empty state (muted history icon + message), and exposes a way to configure the message from the relation manager.

### Changes
- **`resources/views/timeline.blade.php`** — empty state is now a centered block with a `ri-history-line` icon and the message, instead of a small left-aligned gray `<p>`. Renders clearly instead of looking like a blank panel.
- **`src/Filament/RelationManagers/ActivityLogRelationManager.php`** — added a `public static ?string $emptyState` and now passes it (falling back to the `activity-log::messages.empty_state` translation) into the Livewire component. Previously the relation manager mounted the component without an empty-state value, so host apps had no way to set the message on this path.

## Why

When a record had no activity, the timeline rendered an empty-looking white section. The message now displays prominently, and host apps can customize it via:
- the published translation (`empty_state`),
- `ActivityLogRelationManager::$emptyState`, or
- a relation-manager subclass.

## Testing
- `vendor/bin/pest` — 46 passed