### PR TITLE
Fix #24: Replace Remix icons with Heroicons

### DIFF
--- a/resources/views/entries/activity-log.blade.php
+++ b/resources/views/entries/activity-log.blade.php
@@ -3,7 +3,7 @@
     use Relaticle\ActivityLog\Support\ActivityLogSummary;
 
     $summary = ActivityLogSummary::from($entry);
-    $icon = $summary->operation?->icon() ?? 'ri-edit-line';
+    $icon = $summary->operation?->icon() ?? 'heroicon-o-pencil-square';
 @endphp
 
 <div
@@ -61,7 +61,7 @@
                                 >
                                     {{ $row->formattedOld() }}
                                 </span>
-                                <x-filament::icon icon="ri-arrow-right-line" class="h-3 w-3 shrink-0 text-gray-400" />
+                                <x-filament::icon icon="heroicon-m-arrow-right" class="h-3 w-3 shrink-0 text-gray-400" />
                                 <span
                                     class="line-clamp-2 font-medium text-gray-900 dark:text-gray-100"
                                     title="{{ $row->formattedNew() }}"
@@ -86,7 +86,7 @@
         </time>
         @if ($summary->hasDiff)
             <x-filament::icon
-                icon="ri-arrow-down-s-line"
+                icon="heroicon-m-chevron-down"
                 class="h-4 w-4 text-gray-400 transition-transform"
                 x-bind:class="open ? 'rotate-180' : ''"
                 aria-hidden="true"

--- a/resources/views/entries/default.blade.php
+++ b/resources/views/entries/default.blade.php
@@ -16,7 +16,7 @@
 >
     <div class="flex justify-center pt-0.5">
         <span class="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-600 ring-1 ring-gray-200 dark:bg-white/5 dark:text-gray-300 dark:ring-white/10">
-            <x-filament::icon icon="ri-circle-line" class="h-3.5 w-3.5" />
+            <span class="h-1.5 w-1.5 rounded-full bg-current"></span>
         </span>
     </div>
 

--- a/resources/views/timeline.blade.php
+++ b/resources/views/timeline.blade.php
@@ -22,7 +22,7 @@
                         @click="open = !open"
                     >
                         <x-filament::icon
-                            icon="ri-arrow-down-s-line"
+                            icon="heroicon-m-chevron-down"
                             class="h-4 w-4 transition-transform"
                             x-bind:class="open ? '' : '-rotate-90'"
                         />
@@ -79,7 +79,7 @@
                     wire:click="loadMore"
                     wire:loading.attr="disabled"
                     wire:target="loadMore"
-                    icon="ri-arrow-down-line"
+                    icon="heroicon-m-arrow-down"
                 >
                     <span wire:loading.remove wire:target="loadMore">{{ __('activity-log::messages.load_more') }}</span>
                     <span wire:loading wire:target="loadMore">{{ __('activity-log::messages.loading') }}</span>

--- a/src/Support/ActivityLogOperation.php
+++ b/src/Support/ActivityLogOperation.php
@@ -14,10 +14,10 @@ enum ActivityLogOperation: string
     public function icon(): string
     {
         return match ($this) {
-            self::Created => 'ri-add-line',
-            self::Deleted => 'ri-delete-bin-line',
-            self::Restored => 'ri-arrow-go-back-line',
-            self::Updated => 'ri-edit-line',
+            self::Created => 'heroicon-o-plus',
+            self::Deleted => 'heroicon-o-trash',
+            self::Restored => 'heroicon-o-arrow-uturn-left',
+            self::Updated => 'heroicon-o-pencil-square',
         };
     }
 


### PR DESCRIPTION
## Problem

Closes #24. The package referenced Remix icons (`ri-*`) but did not declare the `andreiio/blade-remix-icon` package. Consumers without that package hit:

> Svg by name "ri-arrow-down-s-line" from set "default" not found

## Fix

Replace all `ri-*` icons with Heroicons, which Filament ships by default — no extra dependency required.

| Old (`ri-*`) | New (`heroicon-*`) |
|---|---|
| `ri-arrow-down-s-line` | `heroicon-m-chevron-down` |
| `ri-arrow-down-line` | `heroicon-m-arrow-down` |
| `ri-arrow-right-line` | `heroicon-m-arrow-right` |
| `ri-add-line` | `heroicon-o-plus` |
| `ri-delete-bin-line` | `heroicon-o-trash` |
| `ri-arrow-go-back-line` | `heroicon-o-arrow-uturn-left` |
| `ri-edit-line` | `heroicon-o-pencil-square` |
| `ri-circle-line` | CSS dot (no circle icon in Heroicons) |

## Files

- `resources/views/timeline.blade.php`
- `resources/views/entries/activity-log.blade.php`
- `resources/views/entries/default.blade.php`
- `src/Support/ActivityLogOperation.php`

## Tests

`vendor/bin/pest` — 46 passed.