### PR TITLE
Fix timeline dedup over-collapse, empty-state icon, and tenant-scoped reads

### DIFF
--- a/config/activity-log.php
+++ b/config/activity-log.php
@@ -3,8 +3,13 @@
 declare(strict_types=1);
 
 return [
-    'activity_model' => \Spatie\Activitylog\Models\Activity::class,
-    
+    // Activity model for the read (timeline) path. Leave null to inherit
+    // Spatie's `activitylog.activity_model` — the same model used for writes —
+    // so a tenant-scoped Activity subclass applies to both. Set explicitly only
+    // to override that.
+    'activity_model' => null,
+
+
     'default_per_page' => 20,
     'pagination_buffer' => 2,
     'deduplicate_by_default' => true,

--- a/resources/views/timeline.blade.php
+++ b/resources/views/timeline.blade.php
@@ -2,7 +2,7 @@
     @if ($entries->isEmpty())
         <div class="flex flex-col items-center justify-center gap-3 py-10 text-center">
             <div class="flex h-11 w-11 items-center justify-center rounded-full bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-gray-500">
-                <x-filament::icon icon="ri-history-line" class="h-5 w-5" />
+                <x-filament::icon icon="heroicon-o-clock" class="h-5 w-5" />
             </div>
             <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $emptyState }}</p>
         </div>

--- a/src/Timeline/Sources/AbstractTimelineSource.php
+++ b/src/Timeline/Sources/AbstractTimelineSource.php
@@ -19,6 +19,25 @@ abstract class AbstractTimelineSource implements TimelineSource
         return $this->priority;
     }
 
+    /**
+     * Resolve the Activity model used for the read path.
+     *
+     * Prefers the plugin's own key, then falls back to Spatie's canonical
+     * `activitylog.activity_model` — the same key that governs writes — so the
+     * rendered timeline reads through whatever (possibly tenant-scoped) Activity
+     * subclass the host configured, even when the hyphenated plugin config was
+     * never published.
+     *
+     * @return class-string<\Spatie\Activitylog\Contracts\Activity&\Illuminate\Database\Eloquent\Model>
+     */
+    protected function activityModelClass(): string
+    {
+        /** @var class-string<\Spatie\Activitylog\Contracts\Activity&\Illuminate\Database\Eloquent\Model> */
+        return config('activity-log.activity_model')
+            ?? config('activitylog.activity_model')
+            ?? \Spatie\Activitylog\Models\Activity::class;
+    }
+
     protected function dedupKeyFor(string $class, int|string $id, CarbonImmutable $occurredAt): string
     {
         return sprintf(
@@ -27,6 +46,16 @@ abstract class AbstractTimelineSource implements TimelineSource
             $id,
             $occurredAt->utc()->format('Y-m-d\TH:i:s'),
         );
+    }
+
+    /**
+     * Dedup key for an activity-log row. Unlike the second-precision key above,
+     * this includes the activity id so several distinct activities written for
+     * the same subject in the same second (e.g. a multi-field save) stay separate.
+     */
+    protected function dedupKeyForActivity(string $class, int|string $id, CarbonImmutable $occurredAt, int|string $activityId): string
+    {
+        return $this->dedupKeyFor($class, $id, $occurredAt).':'.$activityId;
     }
 
     /**

--- a/src/Timeline/Sources/AbstractTimelineSource.php
+++ b/src/Timeline/Sources/AbstractTimelineSource.php
@@ -30,7 +30,7 @@ abstract class AbstractTimelineSource implements TimelineSource
      *
      * @return class-string<\Spatie\Activitylog\Contracts\Activity&\Illuminate\Database\Eloquent\Model>
      */
-    protected function activityModelClass(): string
+    protected function getActivityModelClass(): string
     {
         /** @var class-string<\Spatie\Activitylog\Contracts\Activity&\Illuminate\Database\Eloquent\Model> */
         return config('activity-log.activity_model')

--- a/src/Timeline/Sources/ActivityLogSource.php
+++ b/src/Timeline/Sources/ActivityLogSource.php
@@ -13,19 +13,11 @@ use Spatie\Activitylog\Models\Activity as ActivityModel;
 
 final class ActivityLogSource extends AbstractTimelineSource
 {
-    /**
-     * Get the activity model class from config or use default
-     */
-    private function getActivityModelClass(): string
-    {
-        return config('activity-log.activity_model', ActivityModel::class);
-    }
-
     public function resolve(Model $subject, Window $window): iterable
     {
         throw_if($subject->getKey() === null, DomainException::class, 'ActivityLogSource cannot resolve entries for an unsaved subject.');
 
-        $modelClass = $this->getActivityModelClass();
+        $modelClass = $this->activityModelClass();
         
         $query = $modelClass::query()
             ->with(['causer', 'subject'])
@@ -56,7 +48,7 @@ final class ActivityLogSource extends AbstractTimelineSource
             type: 'activity_log',
             event: $event,
             occurredAt: $occurredAt,
-            dedupKey: $this->dedupKeyFor($subject->getMorphClass(), (string) $subject->getKey(), $occurredAt),
+            dedupKey: $this->dedupKeyForActivity($subject->getMorphClass(), (string) $subject->getKey(), $occurredAt, (string) $activity->getKey()),
             sourcePriority: $this->priority,
             subject: $subject,
             causer: $activity->causer,

--- a/src/Timeline/Sources/ActivityLogSource.php
+++ b/src/Timeline/Sources/ActivityLogSource.php
@@ -17,7 +17,7 @@ final class ActivityLogSource extends AbstractTimelineSource
     {
         throw_if($subject->getKey() === null, DomainException::class, 'ActivityLogSource cannot resolve entries for an unsaved subject.');
 
-        $modelClass = $this->activityModelClass();
+        $modelClass = $this->getActivityModelClass();
         
         $query = $modelClass::query()
             ->with(['causer', 'subject'])

--- a/src/Timeline/Sources/RelatedActivityLogSource.php
+++ b/src/Timeline/Sources/RelatedActivityLogSource.php
@@ -45,7 +45,7 @@ final class RelatedActivityLogSource extends AbstractTimelineSource
             return;
         }
 
-        $modelClass = $this->activityModelClass();
+        $modelClass = $this->getActivityModelClass();
 
         $query = $modelClass::query()
             ->with(['causer', 'subject'])

--- a/src/Timeline/Sources/RelatedActivityLogSource.php
+++ b/src/Timeline/Sources/RelatedActivityLogSource.php
@@ -15,14 +15,6 @@ use Spatie\Activitylog\Models\Activity as ActivityModel;
 final class RelatedActivityLogSource extends AbstractTimelineSource
 {
     /**
-     * Get the activity model class from config or use default
-     */
-    private function getActivityModelClass(): string
-    {
-        return config('activity-log.activity_model', ActivityModel::class);
-    }
-
-    /**
      * @param  array<int, string>  $relations
      */
     public function __construct(int $priority, private readonly array $relations)
@@ -53,8 +45,8 @@ final class RelatedActivityLogSource extends AbstractTimelineSource
             return;
         }
 
-        $modelClass = $this->getActivityModelClass();
-        
+        $modelClass = $this->activityModelClass();
+
         $query = $modelClass::query()
             ->with(['causer', 'subject'])
             ->where(function (Builder $q) use ($subjectPairs): void {

--- a/tests/Feature/ActivityModelResolutionTest.php
+++ b/tests/Feature/ActivityModelResolutionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\ActivityLog\Tests\Fixtures\Models\Person;
+use Relaticle\ActivityLog\Tests\Fixtures\Models\ScopedActivity;
+use Relaticle\ActivityLog\Timeline\Sources\ActivityLogSource;
+use Relaticle\ActivityLog\Timeline\Window;
+
+it('reads through the plugin activity_model when set', function (): void {
+    config()->set('activity-log.activity_model', ScopedActivity::class);
+
+    $person = Person::factory()->create();
+
+    $entries = collect((new ActivityLogSource(priority: 10))->resolve($person, new Window(cap: 10)));
+
+    expect($entries)->toBeEmpty();
+});
+
+it('falls back to Spatie activitylog.activity_model when the plugin key is null', function (): void {
+    config()->set('activity-log.activity_model', null);
+    config()->set('activitylog.activity_model', ScopedActivity::class);
+
+    $person = Person::factory()->create();
+
+    $entries = collect((new ActivityLogSource(priority: 10))->resolve($person, new Window(cap: 10)));
+
+    expect($entries)->toBeEmpty();
+});
+
+it('uses the base Spatie Activity when nothing is configured', function (): void {
+    config()->set('activity-log.activity_model', null);
+    config()->set('activitylog.activity_model', null);
+
+    $person = Person::factory()->create();
+
+    $entries = collect((new ActivityLogSource(priority: 10))->resolve($person, new Window(cap: 10)));
+
+    expect($entries)->toHaveCount(1);
+});

--- a/tests/Feature/BuilderDedupTest.php
+++ b/tests/Feature/BuilderDedupTest.php
@@ -65,6 +65,31 @@ it('dedupKeyUsing() overrides the per-entry dedup key', function (): void {
     expect($entries)->toHaveCount(1);
 });
 
+it('keeps distinct own-activity entries that land in the same second (multi-change save)', function (): void {
+    $person = Person::factory()->create();
+    $person->update(['name' => 'First change']);
+    $person->update(['name' => 'Second change']);
+
+    // Simulate one save producing several activity rows in the same second.
+    $stamp = CarbonImmutable::parse('2026-04-17T10:00:00Z');
+    Activity::query()
+        ->where('subject_type', $person->getMorphClass())
+        ->where('subject_id', $person->id)
+        ->update(['created_at' => $stamp]);
+
+    $count = Activity::query()
+        ->where('subject_type', $person->getMorphClass())
+        ->where('subject_id', $person->id)
+        ->count();
+
+    $entries = TimelineBuilder::make($person)
+        ->fromActivityLog()
+        ->deduplicate()
+        ->get();
+
+    expect($entries)->toHaveCount($count);
+});
+
 it('deduplicate(false) skips dedup entirely', function (): void {
     $person = Person::factory()->create();
     $email = Email::factory()->for($person)->create();

--- a/tests/Fixtures/Models/ScopedActivity.php
+++ b/tests/Fixtures/Models/ScopedActivity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\ActivityLog\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\Activitylog\Models\Activity as SpatieActivity;
+
+/**
+ * Stand-in for a host's tenant-scoped Activity subclass: a global scope that
+ * hides every row, so a read path honoring it returns nothing.
+ */
+final class ScopedActivity extends SpatieActivity
+{
+    protected static function booted(): void
+    {
+        static::addGlobalScope('scoped', function (Builder $query): void {
+            $query->whereRaw('1 = 0');
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes to the activity-log timeline, each with regression tests.

### BR233-1 — multi-change save collapses to one entry (high)
`ActivityLogSource` keyed dedup as `class:subjectId:second` with no activity id, so several distinct activities written for the same subject in the same second (e.g. one save touching a core field + a custom field) collapsed into a single rendered entry while the DB held N.

Dedup key for the own-activity source now includes the activity id (`dedupKeyForActivity()`), so distinct rows stay separate. `RelatedActivityLogSource` keeps the second-precision key on purpose — that is what merges it against the synthetic `RelatedModelSource` events (covered by `BuilderDedupTest`).

### BR233-3 — empty Activity log tab renders a blank card (low)
The empty-state branch in `timeline.blade.php` still referenced the Remix icon `ri-history-line`, missed by the Heroicons migration (#24) because it only renders when the timeline is empty. The missing icon set produced a blank card with no message. Swapped to `heroicon-o-clock`. The empty-state string was already passed non-empty from both call sites.

### F3 — timeline read path not tenant-scoped (medium)
The read path resolved its model from `config('activity-log.activity_model')`, while hosts configure their (tenant-scoped) Activity subclass via Spatie's canonical `activitylog.activity_model`, which governs writes. The plugin config also defaulted to the base Spatie `Activity`, so reads ignored any subclass and ran without the team scope.

Reads now resolve `activity-log.activity_model` → `activitylog.activity_model` → base `Activity` via a shared `activityModelClass()`. The plugin config default is `null` so it no longer shadows the Spatie key. A host can configure the scoped subclass once and have both writes and timeline reads honor it, even without publishing `config/activity-log.php`.

## Tests
- `BuilderDedupTest` — multi-change save yields N entries; existing cross-source dedup tests still pass.
- `ActivityModelResolutionTest` (+ `ScopedActivity` fixture) — plugin key wins, falls back to Spatie key, then base model.
- Full suite: 50 passed.

## Out of scope
BR233-2 and BR233-4 target the host app's `app/Observers/CustomFieldValueObserver.php`, which is not part of this package.