### PR TITLE
feat: add Filament icon alias support for UI customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .phpunit.result.cache
 .DS_Store
 .planning/
+.idea/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A unified chronological timeline for any Eloquent model. Aggregates `spatie/lara
 - **Filament-native UX** — infolist component, relation manager, and header-action slide-over
 - **Dedup + filtering** — type/event allow/deny lists, date windows, priority-based dedup with override
 - **Opt-in caching** — per-call TTL with explicit invalidation — no model observers
+- **Icon customization** — override default package UI icons using Filament's built-in Icon Alias registry
 
 ## Requirements
 

--- a/docs/content/3.essentials/7.icon-aliases.md
+++ b/docs/content/3.essentials/7.icon-aliases.md
@@ -1,0 +1,65 @@
+---
+title: Icon Aliases
+description: Customizing the package's default icons using Filament's icon alias registry.
+navigation:
+  icon: i-lucide-image
+seo:
+  description: Learn how to customize ActivityLog icons in Filament using Icon Aliases.
+  ogImage: /preview.png
+---
+
+Every icon rendered by the package can be customized using Filament's built-in [Icon Alias Registry](https://filamentphp.com/docs/5.x/styling/icons#available-icon-aliases).
+
+This allows you to replace the default Heroicons with your own custom SVG icons, or icons from another set, without needing to publish or override any blade views.
+
+## **Customizing an icon**
+
+To override an icon, call `FilamentIcon::register()` from the `boot()` method of your `AppServiceProvider` (or any other service provider). You must use the constants provided by `Relaticle\\ActivityLog\\Icons\\ActivityLogIconAlias` as the keys.
+
+```php
+use Filament\\Support\\Facades\\FilamentIcon;  
+use Relaticle\\ActivityLog\\Icons\\ActivityLogIconAlias;
+
+public function boot(): void  
+{  
+    FilamentIcon::register([  
+        ActivityLogIconAlias::ACTION_ICON => 'heroicon-o-sparkles',  
+        ActivityLogIconAlias::TIMELINE_EMPTY => 'heroicon-o-face-frown',  
+    ]);  
+}
+```
+
+## **Available aliases**
+
+### **Operations**
+
+Icons used alongside standard and custom activity log operations.
+
+| Alias Constant           | Default Icon                |
+|:-------------------------|:----------------------------|
+| LOG\_OPERATION\_CREATED  | heroicon-o-plus             |
+| LOG\_OPERATION\_DELETED  | heroicon-o-trash            |
+| LOG\_OPERATION\_RESTORED | heroicon-o-arrow-uturn-left |
+| LOG\_OPERATION\_UPDATED  | heroicon-o-pencil-square    |
+| LOG\_OPERATION\_UNKNOWN  | heroicon-o-pencil-square    |
+
+### **Timeline UI**
+
+Icons used in the timeline views and entry cards.
+
+| Alias Constant               | Default Icon            |
+|:-----------------------------|:------------------------|
+| LOG\_COLLAPSE\_BUTTON        | heroicon-m-chevron-down |
+| LOG\_VALUE\_DIFF             | heroicon-m-arrow-right  |
+| TIMELINE\_COLLAPSE\_BUTTON   | heroicon-m-chevron-down |
+| TIMELINE\_LOAD\_MORE\_BUTTON | heroicon-m-arrow-down   |
+| TIMELINE\_EMPTY              | heroicon-o-clock        |
+
+### **Filament Surfaces**
+
+Icons used by the package's Filament integrations.
+
+| Alias Constant          | Default Icon                  |
+|:------------------------|:------------------------------|
+| ACTION\_ICON            | heroicon-o-bars-3-bottom-left |
+| RELATION\_MANAGER\_ICON | heroicon-o-clock              |

--- a/resources/views/entries/activity-log.blade.php
+++ b/resources/views/entries/activity-log.blade.php
@@ -1,31 +1,32 @@
 @php
+    use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
     use Relaticle\ActivityLog\Support\ActivityLogOperation;
     use Relaticle\ActivityLog\Support\ActivityLogSummary;
 
     $summary = ActivityLogSummary::from($entry);
-    $icon = $summary->operation?->icon() ?? 'heroicon-o-pencil-square';
+    $icon = $summary->operation?->icon() ?? ActivityLogIconAlias::LOG_OPERATION_UNKNOWN;
 @endphp
 
 <div
-    x-data="{ open: false }"
-    data-type="{{ $entry->type }}"
-    data-event="{{ $entry->event }}"
-    @class([
-        'group grid grid-cols-[28px_1fr_auto] items-start gap-x-3 rounded-md px-2 py-2 transition',
-        'cursor-pointer hover:bg-gray-50/60 dark:hover:bg-white/[0.03]' => $summary->hasDiff,
-    ])
-    @if ($summary->hasDiff)
-        role="button"
+        x-data="{ open: false }"
+        data-type="{{ $entry->type }}"
+        data-event="{{ $entry->event }}"
+        @class([
+            'group grid grid-cols-[28px_1fr_auto] items-start gap-x-3 rounded-md px-2 py-2 transition',
+            'cursor-pointer hover:bg-gray-50/60 dark:hover:bg-white/[0.03]' => $summary->hasDiff,
+        ])
+        @if ($summary->hasDiff)
+            role="button"
         tabindex="0"
         :aria-expanded="open.toString()"
         @click="open = !open"
         @keydown.enter.prevent="open = !open"
         @keydown.space.prevent="open = !open"
-    @endif
+        @endif
 >
     <div class="flex justify-center pt-0.5">
         <span class="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-600 ring-1 ring-gray-200 dark:bg-white/5 dark:text-gray-300 dark:ring-white/10">
-            <x-filament::icon :icon="$icon" class="h-3.5 w-3.5" />
+            <x-filament::icon :alias="$icon" class="h-3.5 w-3.5"/>
         </span>
     </div>
 
@@ -56,15 +57,16 @@
                             </dt>
                             <dd class="flex flex-wrap items-center gap-2 text-gray-700 dark:text-gray-300">
                                 <span
-                                    class="line-clamp-2 text-gray-500 line-through decoration-gray-400/50 dark:text-gray-500"
-                                    title="{{ $row->formattedOld() }}"
+                                        class="line-clamp-2 text-gray-500 line-through decoration-gray-400/50 dark:text-gray-500"
+                                        title="{{ $row->formattedOld() }}"
                                 >
                                     {{ $row->formattedOld() }}
                                 </span>
-                                <x-filament::icon icon="heroicon-m-arrow-right" class="h-3 w-3 shrink-0 text-gray-400" />
+                                <x-filament::icon :alias="ActivityLogIconAlias::LOG_VALUE_DIFF"
+                                                  class="h-3 w-3 shrink-0 text-gray-400"/>
                                 <span
-                                    class="line-clamp-2 font-medium text-gray-900 dark:text-gray-100"
-                                    title="{{ $row->formattedNew() }}"
+                                        class="line-clamp-2 font-medium text-gray-900 dark:text-gray-100"
+                                        title="{{ $row->formattedNew() }}"
                                 >
                                     {{ $row->formattedNew() }}
                                 </span>
@@ -78,18 +80,18 @@
 
     <div class="flex items-center gap-1.5 pt-0.5">
         <time
-            class="text-[11px] text-gray-500 dark:text-gray-400 tabular-nums"
-            datetime="{{ $entry->occurredAt->toIso8601String() }}"
-            title="{{ $entry->occurredAt->toDayDateTimeString() }}"
+                class="text-[11px] text-gray-500 dark:text-gray-400 tabular-nums"
+                datetime="{{ $entry->occurredAt->toIso8601String() }}"
+                title="{{ $entry->occurredAt->toDayDateTimeString() }}"
         >
             {{ $entry->occurredAt->diffForHumans(syntax: null, short: true) }}
         </time>
         @if ($summary->hasDiff)
             <x-filament::icon
-                icon="heroicon-m-chevron-down"
-                class="h-4 w-4 text-gray-400 transition-transform"
-                x-bind:class="open ? 'rotate-180' : ''"
-                aria-hidden="true"
+                    :alias="ActivityLogIconAlias::LOG_COLLAPSE_BUTTON"
+                    class="h-4 w-4 text-gray-400 transition-transform"
+                    x-bind:class="open ? 'rotate-180' : ''"
+                    aria-hidden="true"
             />
         @endif
     </div>

--- a/resources/views/timeline.blade.php
+++ b/resources/views/timeline.blade.php
@@ -1,8 +1,10 @@
+@use(Relaticle\ActivityLog\Icons\ActivityLogIconAlias)
+
 <div class="flex flex-col gap-6">
     @if ($entries->isEmpty())
         <div class="flex flex-col items-center justify-center gap-3 py-10 text-center">
             <div class="flex h-11 w-11 items-center justify-center rounded-full bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-gray-500">
-                <x-filament::icon icon="heroicon-o-clock" class="h-5 w-5" />
+                <x-filament::icon :alias="ActivityLogIconAlias::TIMELINE_EMPTY" class="h-5 w-5" />
             </div>
             <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $emptyState }}</p>
         </div>
@@ -27,7 +29,7 @@
                         @click="open = !open"
                     >
                         <x-filament::icon
-                            icon="heroicon-m-chevron-down"
+                            :alias="ActivityLogIconAlias::TIMELINE_COLLAPSE_BUTTON"
                             class="h-4 w-4 transition-transform"
                             x-bind:class="open ? '' : '-rotate-90'"
                         />
@@ -84,7 +86,9 @@
                     wire:click="loadMore"
                     wire:loading.attr="disabled"
                     wire:target="loadMore"
-                    icon="heroicon-m-arrow-down"
+                    {{-- Filament requires 'icon' to be set before it will resolve the 'icon-alias' --}}
+                    :icon="ActivityLogIconAlias::TIMELINE_LOAD_MORE_BUTTON"
+                    :icon-alias="ActivityLogIconAlias::TIMELINE_LOAD_MORE_BUTTON"
                 >
                     <span wire:loading.remove wire:target="loadMore">{{ __('activity-log::messages.load_more') }}</span>
                     <span wire:loading wire:target="loadMore">{{ __('activity-log::messages.loading') }}</span>

--- a/src/ActivityLogServiceProvider.php
+++ b/src/ActivityLogServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Relaticle\ActivityLog;
 
+use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Foundation\Application;
 use Livewire\Livewire;
+use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
 use Relaticle\ActivityLog\Renderers\RendererRegistry;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -29,6 +31,23 @@ final class ActivityLogServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
+        FilamentIcon::register([
+            ActivityLogIconAlias::LOG_OPERATION_CREATED => 'heroicon-o-plus',
+            ActivityLogIconAlias::LOG_OPERATION_DELETED => 'heroicon-o-trash',
+            ActivityLogIconAlias::LOG_OPERATION_RESTORED => 'heroicon-o-arrow-uturn-left',
+            ActivityLogIconAlias::LOG_OPERATION_UPDATED => 'heroicon-o-pencil-square',
+            ActivityLogIconAlias::LOG_OPERATION_UNKNOWN => 'heroicon-o-pencil-square',
+            ActivityLogIconAlias::LOG_COLLAPSE_BUTTON => 'heroicon-m-chevron-down',
+            ActivityLogIconAlias::LOG_VALUE_DIFF => 'heroicon-m-arrow-right',
+
+            ActivityLogIconAlias::TIMELINE_COLLAPSE_BUTTON => 'heroicon-m-chevron-down',
+            ActivityLogIconAlias::TIMELINE_LOAD_MORE_BUTTON => 'heroicon-m-arrow-down',
+            ActivityLogIconAlias::TIMELINE_EMPTY => 'heroicon-o-clock',
+
+            ActivityLogIconAlias::ACTION_ICON => 'heroicon-o-bars-3-bottom-left',
+            ActivityLogIconAlias::RELATION_MANAGER_ICON => 'heroicon-o-clock',
+        ]);
+
         Livewire::component('activity-log', Filament\Livewire\ActivityLogLivewire::class);
 
         $registry = $this->app->make(RendererRegistry::class);

--- a/src/Filament/Actions/ActivityLogAction.php
+++ b/src/Filament/Actions/ActivityLogAction.php
@@ -8,8 +8,10 @@ use Filament\Actions\Action;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\ActivityLog\Filament\Livewire\ActivityLogLivewire;
+use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
 
 final class ActivityLogAction extends Action
 {
@@ -24,7 +26,7 @@ final class ActivityLogAction extends Action
 
         $this
             ->label(__('activity-log::messages.title'))
-            ->icon('heroicon-o-bars-3-bottom-left')
+            ->icon(FilamentIcon::resolve(ActivityLogIconAlias::ACTION_ICON))
             ->color('gray')
             ->modalHeading(__('activity-log::messages.title'))
             ->modalDescription(__('activity-log::messages.modal_description'))
@@ -32,12 +34,12 @@ final class ActivityLogAction extends Action
             ->modalSubmitAction(false)
             ->modalCancelActionLabel(__('activity-log::messages.close'))
             ->slideOver()
-            ->schema(fn (Schema $schema, Model $record): Schema => $schema->components([
+            ->schema(fn(Schema $schema, Model $record): Schema => $schema->components([
                 Livewire::make(ActivityLogLivewire::class, [
                     'subjectClass' => $record::class,
                     'subjectKey' => $record->getKey(),
                     'groupByDate' => true,
-                ])->key('activity-log-action-'.$record->getKey()),
+                ])->key('activity-log-action-' . $record->getKey()),
             ]));
     }
 }

--- a/src/Filament/RelationManagers/ActivityLogRelationManager.php
+++ b/src/Filament/RelationManagers/ActivityLogRelationManager.php
@@ -9,10 +9,13 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Facades\FilamentIcon;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Relaticle\ActivityLog\Filament\Livewire\ActivityLogLivewire;
+use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
 
 final class ActivityLogRelationManager extends RelationManager
 {
@@ -23,7 +26,10 @@ final class ActivityLogRelationManager extends RelationManager
         return (string) __('activity-log::messages.title');
     }
 
-    protected static string|BackedEnum|null $icon = 'heroicon-o-clock';
+    public static function getIcon(Model $ownerRecord, string $pageClass): string|BackedEnum|Htmlable|null
+    {
+        return FilamentIcon::resolve(ActivityLogIconAlias::RELATION_MANAGER_ICON);
+    }
 
     public static bool $infiniteScroll = true;
 

--- a/src/Icons/ActivityLogIconAlias.php
+++ b/src/Icons/ActivityLogIconAlias.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\ActivityLog\Icons;
+
+class ActivityLogIconAlias
+{
+    const string LOG_OPERATION_CREATED = 'relaticle::activity-log::log.operation-created';
+    const string LOG_OPERATION_DELETED = 'relaticle::activity-log::log.operation-deleted';
+    const string LOG_OPERATION_RESTORED = 'relaticle::activity-log::log.operation-restored';
+    const string LOG_OPERATION_UPDATED = 'relaticle::activity-log::log.operation-updated';
+    const string LOG_OPERATION_UNKNOWN = 'relaticle::activity-log::log.operation-unknown';
+    const string LOG_COLLAPSE_BUTTON = 'relaticle::activity-log::log.collapse-button';
+    const string LOG_VALUE_DIFF = 'relaticle::activity-log::log.value-diff';
+
+    const string TIMELINE_COLLAPSE_BUTTON = 'relaticle::activity-log::timeline.collapse-button';
+    const string TIMELINE_LOAD_MORE_BUTTON = 'relaticle::activity-log::timeline.load-more-button';
+    const string TIMELINE_EMPTY = 'relaticle::activity-log::timeline.empty';
+
+    const string ACTION_ICON = 'relaticle::activity-log::action.icon';
+    const string RELATION_MANAGER_ICON = 'relaticle::activity-log::relation-manager.icon';
+}

--- a/src/Support/ActivityLogOperation.php
+++ b/src/Support/ActivityLogOperation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\ActivityLog\Support;
 
+use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
+
 enum ActivityLogOperation: string
 {
     case Created = 'created';
@@ -14,10 +16,10 @@ enum ActivityLogOperation: string
     public function icon(): string
     {
         return match ($this) {
-            self::Created => 'heroicon-o-plus',
-            self::Deleted => 'heroicon-o-trash',
-            self::Restored => 'heroicon-o-arrow-uturn-left',
-            self::Updated => 'heroicon-o-pencil-square',
+            self::Created => ActivityLogIconAlias::LOG_OPERATION_CREATED,
+            self::Deleted => ActivityLogIconAlias::LOG_OPERATION_DELETED,
+            self::Restored => ActivityLogIconAlias::LOG_OPERATION_RESTORED,
+            self::Updated => ActivityLogIconAlias::LOG_OPERATION_UPDATED,
         };
     }
 

--- a/tests/Feature/IconAliasTest.php
+++ b/tests/Feature/IconAliasTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Facades\FilamentIcon;
+use Relaticle\ActivityLog\Icons\ActivityLogIconAlias;
+
+it('registers default icon aliases during package boot', function (): void {
+    expect(FilamentIcon::resolve(ActivityLogIconAlias::LOG_OPERATION_CREATED))->toBe('heroicon-o-plus')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_OPERATION_DELETED))->toBe('heroicon-o-trash')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_OPERATION_RESTORED))->toBe('heroicon-o-arrow-uturn-left')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_OPERATION_UPDATED))->toBe('heroicon-o-pencil-square')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_OPERATION_UNKNOWN))->toBe('heroicon-o-pencil-square')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_COLLAPSE_BUTTON))->toBe('heroicon-m-chevron-down')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::LOG_VALUE_DIFF))->toBe('heroicon-m-arrow-right')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::TIMELINE_COLLAPSE_BUTTON))->toBe('heroicon-m-chevron-down')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::TIMELINE_LOAD_MORE_BUTTON))->toBe('heroicon-m-arrow-down')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::TIMELINE_EMPTY))->toBe('heroicon-o-clock')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::ACTION_ICON))->toBe('heroicon-o-bars-3-bottom-left')
+        ->and(FilamentIcon::resolve(ActivityLogIconAlias::RELATION_MANAGER_ICON))->toBe('heroicon-o-clock');
+});
+
+it('allows overriding default icon aliases', function (): void {
+    // Simulate a developer overriding an icon in their AppServiceProvider
+    FilamentIcon::register([
+        ActivityLogIconAlias::ACTION_ICON => 'heroicon-o-sparkles',
+    ]);
+
+    expect(FilamentIcon::resolve(ActivityLogIconAlias::ACTION_ICON))->toBe('heroicon-o-sparkles');
+});


### PR DESCRIPTION
Hi there! 👋

First, thank you so much for this very awesome library ❤️! It's incredibly clean, well thought out, and an absolute joy to use.

I am submitting a PR to introduce Filament's built-in Icon Alias feature to the package. This allows us to easily replace the default Heroicons used throughout the package (timeline, relation managers, header actions, operation types) with their own custom icons, entirely avoiding the need to customize every component, publish or override Blade views.

### Sample Usage:
Developers can now effortlessly override default icons directly in their service providers:

```php
use Filament\\Support\\Facades\\FilamentIcon;  
use Relaticle\\ActivityLog\\Icons\\ActivityLogIconAlias;

public function boot(): void  
{  
    FilamentIcon::register([  
        ActivityLogIconAlias::ACTION_ICON => 'heroicon-o-sparkles',  
        ActivityLogIconAlias::TIMELINE_EMPTY => 'heroicon-o-face-frown',  
    ]);  
}
```

### Changes Included:
- Added `ActivityLogIconAlias` class containing constants for all customizable icons.
- Registered default icons natively using `FilamentIcon::register()` in the `ActivityLogServiceProvider` > `packageBooted()` method.
- Updated all Blade views and UI classes to resolve icons via `<x-filament::icon :alias="...">` and `FilamentIcon::resolve()`.
- Added comprehensive Pest tests (`IconAliasTest.php`) to ensure defaults register correctly and can be overridden.
- Added a new "Icon Aliases" Nuxt Docus page, and added the feature to the `README.md` list.

All tests are passing locally! Please let me know if you need any tweaks or changes. Thanks again for your hard work on this!

