### PR TITLE
Pin GitHub Actions to SHAs, add Dependabot, trim dist archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+# Development-only paths, excluded from the dist archive that Composer installs.
+/.github            export-ignore
+/art                export-ignore
+/docs               export-ignore
+/tests              export-ignore
+/phpunit.xml.dist   export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+updates:
+  # Keep workflow actions up to date. Dependabot rewrites the pinned SHA and
+  # the trailing version comment together, so pinning stays maintainable.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      php-dev-dependencies:
+        dependency-type: development
+        patterns: ["*"]
+    labels:
+      - dependencies
+      - php
+
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      docs-dependencies:
+        patterns: ["*"]
+    labels:
+      - dependencies
+      - docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,18 +53,18 @@ jobs:
           esac
 
       - name: Checkout source branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ steps.version.outputs.branch }}
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, fileinfo
@@ -35,7 +35,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.stability }}-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
Addresses three supply-chain / packaging findings from a dependency health audit.

## 1. Pin all GitHub Actions to full commit SHAs

Every `uses:` ref across both workflows previously pointed at a mutable tag (`@v6`, `@v2`, `@v4`). Tags can be force-moved by the action's owner, so a compromised upstream repo could silently change what runs in CI — including in the docs workflow, which holds `contents: write`.

All six refs now pin to an immutable commit SHA, with a trailing version comment so the intended version stays readable and Dependabot can rewrite both together:

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `d23441a4…` | v6.1.0 |
| `shivammathur/setup-php` | `f3e473d1…` | 2.37.2 |
| `actions/cache` | `0057852b…` | v4.3.0 |
| `actions/setup-node` | `24997072…` | v6.5.0 |

SHAs were resolved from the GitHub API off the exact tags the workflows already used, so **behaviour is unchanged**. Note `shivammathur/setup-php@v2` is an annotated tag; it was dereferenced to the underlying commit rather than pinning the tag object.

## 2. Add Dependabot config

New `.github/dependabot.yml` covering three ecosystems:

- `github-actions` at `/` — keeps the SHA pins above from going stale, which is the main risk pinning introduces
- `composer` at `/`
- `npm` at `/docs`, where `package-lock.json` lives

Weekly Monday schedule, grouped to keep PR volume low, labelled. A `cooldown` (7d default, 30d major / 7d minor / 3d patch) avoids churn from same-day upstream re-releases. The Composer entry groups **dev dependencies only**, so runtime constraint bumps for a library arrive as individual reviewable PRs.

## 3. Add `.gitattributes` with `export-ignore`

The repo had no `.gitattributes`, so every tracked path shipped in the dist archive that Composer installs. Measured via `git archive` on the resulting tree:

| | Before | After |
|---|---|---|
| Files | 153 | 58 |
| Size | ~2.5 MB | ~123 KB |

The archive now contains only `src/`, `resources/`, `config/`, `composer.json`, and the three docs files — the actual runtime surface. `docs/` (50 files of Nuxt site source) was the bulk of the weight.

Also sets `* text=auto eol=lf`. This is safe to add now: zero tracked files currently contain CRLF, so it triggers no renormalization diff and only governs files added from here on.

## Notes for review

- **`export-ignore` takes effect at tag time.** Already-published archives, including v1.2.0, are unaffected. The size reduction lands on the next release.
- `.gitattributes` export-ignores itself, which is why it isn't in the "after" listing — conventional for Laravel packages, as it carries no meaning for a consumer.
- No source, test, or runtime code is touched; the diff is four files under `.github/` and the repo root.