### PR TITLE
Fix Dependabot config: drop unsupported semver cooldown keys for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,10 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Actions are not semver-versioned as far as Dependabot is concerned, so
+    # only default-days is valid here; the semver-* keys are rejected.
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
Follow-up to #36, which merged before this fix was ready.

## Problem

Dependabot rejects the config that landed in #36:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

The `semver-major-days` / `semver-minor-days` / `semver-patch-days` cooldown keys are only valid for ecosystems Dependabot treats as semver-versioned. `github-actions` is not one of them — actions are referenced by tag or SHA, not by a semver range Dependabot resolves — so only `default-days` is accepted there.

## Impact

A parse error disables the **entire** config file, not just the offending entry. Since #36 merged, Dependabot has not been running for any of the three ecosystems. That includes the `github-actions` entry, which is what keeps the SHA pins from #36 current — so the pins are currently frozen with nothing scheduled to update them. This restores all three.

## Fix

Remove the three `semver-*` keys from the `github-actions` entry, keeping `default-days: 7`. One file, +2/−3.

The `composer` and `npm` entries are unchanged and keep the full granularity (30d major / 7d minor / 3d patch) — both are semver ecosystems, and Dependabot reports all parse errors in a single pass, so the fact that it flagged only `updates/0` confirms those two validate.

A comment is added at the call site so the asymmetry between the three entries doesn't read as an oversight and get "helpfully" restored later.