### PR TITLE
fix: resolve soft-deleted subjects unconditionally

### DIFF
--- a/src/Filament/Livewire/ActivityLogLivewire.php
+++ b/src/Filament/Livewire/ActivityLogLivewire.php
@@ -96,10 +96,7 @@ final class ActivityLogLivewire extends Component
         $class = $this->subjectClass;
 
         return $class::query()
-            ->when(
-                config('activitylog.include_soft_deleted_subjects'),
-                fn ($query) => $query->withoutGlobalScope(SoftDeletingScope::class)
-            )
+            ->withoutGlobalScope(SoftDeletingScope::class)
             ->findOrFail($this->subjectKey);
     }
 

--- a/tests/Feature/SoftDeletedSubjectResolutionTest.php
+++ b/tests/Feature/SoftDeletedSubjectResolutionTest.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 use Relaticle\ActivityLog\Filament\Livewire\ActivityLogLivewire;
 use Relaticle\ActivityLog\Tests\Fixtures\Models\Person;
 
-it('renders when the subject has been soft deleted', function (): void {
-    config()->set('activitylog.include_soft_deleted_subjects', true);
-
+it('resolves the timeline when the subject has been soft deleted', function (): void {
     $person = Person::factory()->create(['name' => 'Soft Deleted Person']);
+    $person->update(['name' => 'Renamed Before Deletion']);
     $person->delete();
 
     expect($person->trashed())->toBeTrue();
@@ -16,8 +15,10 @@ it('renders when the subject has been soft deleted', function (): void {
     $component = new ActivityLogLivewire;
     $component->subjectClass = $person::class;
     $component->subjectKey = $person->getKey();
+    $component->mount();
 
     $view = $component->render();
 
-    expect($view->name())->toBe('activity-log::timeline');
+    expect($view->name())->toBe('activity-log::timeline')
+        ->and($view->getData()['entries'])->not->toBeEmpty();
 });


### PR DESCRIPTION
Follow-up to #39.

That PR gated the soft-delete fix behind Spatie's `activitylog.include_soft_deleted_subjects`, which ships as `false`. On a default install the reported 404 therefore still happens — the fix only activates for users who publish a third-party package's config and flip a setting they have no reason to connect to this bug.

```php
return $class::query()
    ->withoutGlobalScope(SoftDeletingScope::class)
    ->findOrFail($this->subjectKey);
```

### Why that flag is the wrong gate

It governs whether `$activity->subject` resolves a trashed model when you're iterating a list of activity rows — with `false` you get `null` for that one field and the entry still renders. Graceful degradation.

This path is a different question. Filament has already authorized the record and put it on screen, then hands the component `$record::class` + `$record->getKey()` (`ActivityLogAction`, `ActivityLogRelationManager`). The component only re-queries because Livewire has to serialize state between requests — it can't hold the model instance. Failing that re-query throws `ModelNotFoundException` and 404s the entire page, rather than blanking one field.

### Blast radius

Removing the gate changes nothing that currently works:

- Model without `SoftDeletes` → `SoftDeletingScope` was never registered, so removing it is a no-op.
- Soft-deleting model, live record → the scope's `deleted_at is null` would have matched it anyway.
- Soft-deleting model, trashed record → previously 404, now renders. This is the bug.

`resolveSubject()` is the only place subjects are loaded, so this covers the action, the relation manager, and the infolist.

No new config key. One would need someone who'd plausibly want the timeline to 404 on records their panel is configured to show.

### Test

The existing test dropped the `config()->set(...)`, so it now exercises the default path. It also calls `mount()` — without it `visibleCount` stayed `0` and the assertion passed against an empty timeline — and asserts the timeline actually has entries.

Verified the test fails with `ModelNotFoundException` when the production line is reverted. Full suite: 57 passed.