### PR TITLE
chore(ci): add workflow scanning, group security updates, harden checkouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       default-days: 7
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
         patterns: ["*"]
     labels:
       - dependencies
@@ -31,7 +35,11 @@ updates:
       semver-patch-days: 3
     groups:
       php-dev-dependencies:
+        applies-to: version-updates
         dependency-type: development
+        patterns: ["*"]
+      php-security:
+        applies-to: security-updates
         patterns: ["*"]
     labels:
       - dependencies
@@ -49,6 +57,10 @@ updates:
       semver-patch-days: 3
     groups:
       docs-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+      docs-security:
+        applies-to: security-updates
         patterns: ["*"]
     labels:
       - dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,8 +38,9 @@ jobs:
 
       - name: Set version config
         id: config
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
         run: |
-          BRANCH="${{ steps.version.outputs.branch }}"
           case $BRANCH in
             1.x)
               echo "dest_folder=." >> $GITHUB_OUTPUT
@@ -56,8 +57,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.branch }}
+          persist-credentials: false
 
       - name: Checkout gh-pages
+        # zizmor: ignore[artipacked] the deploy commit below pushes with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
@@ -84,10 +87,10 @@ jobs:
           NUXT_PUBLIC_FATHOM_SITE_ID: ${{ secrets.FATHOM_SITE_ID }}
 
       - name: Deploy to gh-pages
+        env:
+          DEST: ${{ steps.config.outputs.dest_folder }}
+          IS_LATEST: ${{ steps.config.outputs.is_latest }}
         run: |
-          DEST="${{ steps.config.outputs.dest_folder }}"
-          IS_LATEST="${{ steps.config.outputs.is_latest }}"
-
           if [ "$IS_LATEST" == "true" ]; then
             echo "Deploying latest version to root..."
             cd gh-pages
@@ -125,6 +128,8 @@ jobs:
 
       - name: Commit and push
         working-directory: ./gh-pages
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -132,6 +137,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to deploy"
           else
-            git commit -m "Deploy ${{ steps.version.outputs.branch }} docs"
+            git commit -m "Deploy $BRANCH docs"
             git push
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["1.x"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Same cleanup as relaticle/custom-fields#217, applied here.

## No workflow scanning at all

This repository has no `zizmor.yml`, so its security tab said "no analysis found" rather than reporting a clean result. Added the audit workflow used by the sibling packages. It finds 8 issues, all fixed here:

- 3 `artipacked`: checkouts persisting a credential they never use.
- 4 `template-injection`: step outputs interpolated straight into `run:` bodies.
- 1 `excessive-permissions`: `tests.yml` declared no `permissions:` block, so it inherited the default token.

Verified with `zizmor --no-online-audits`: 8 findings before, 0 after.

The `gh-pages` checkout in `deploy-docs.yml` is pushed to later in the job, so it keeps its credential and carries an inline ignore saying why.

## Security update grouping

The composer group was scoped to `dependency-type: development`, so production advisories arrived one PR per advisory. Every ecosystem now has a `security-updates` group alongside its version-updates group. `applies-to` defaults to version updates, which the previous groups relied on implicitly.

## Also done outside this PR

Dependabot security updates were disabled on this repository. Now enabled.